### PR TITLE
Erase using Shift. Display saved data locally (console). Select color by pressing space only once.

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -162,6 +162,7 @@ function persist( local ) {
 
 	if ( local ) {
 		console.log(JSON.stringify(data));
+		persistLock = false;
 		return;		
 	}
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -1481,6 +1481,8 @@ palette.init = function() {
 		tool.use(btn.dataset.tool).set(btn.dataset.value);
 
 		active = e.target;
+
+		palette.toggle();
 	});
 };
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -147,7 +147,7 @@ function save(silent) {
 /**
  * @private
  */
-function persist() {
+function persist( local ) {
 	if (persistLock) return;
 	persistLock = true;
 
@@ -159,6 +159,11 @@ function persist() {
 
 	// saves locally
 	var data = save();
+
+	if ( local ) {
+		console.log(JSON.stringify(data));
+		return;		
+	}
 
 	// persist to a gist
 	storage.persist(data, function(err, info) {
@@ -245,7 +250,19 @@ function onKeyDown(e) {
 		// ctrl + s
 		case 83:
 			e.preventDefault();
-			if (e.ctrlKey) persist();
+			if (e.ctrlKey) {
+
+				if (e.shiftKey){
+
+					persist( true );
+
+				} else {
+	
+					persist();
+
+				}
+
+			}
 			break;
 
 		// n

--- a/dist/app.js
+++ b/dist/app.js
@@ -39,6 +39,11 @@ var fullCanvased = false;
 var app = {};
 
 /**
+ *  Shift Detect
+ */
+app.shiftHandler = false;
+
+/**
  *
  */
 app.init = function() {
@@ -98,6 +103,7 @@ function logCurious() {
  */
 function bindShortcuts() {
 	document.addEventListener('keydown', onKeyDown);
+	document.addEventListener('keyup', onKeyUp);
 }
 
 /**
@@ -262,6 +268,23 @@ function onKeyDown(e) {
 	// 123456789
 	if (e.keyCode >= 49 && e.keyCode <= 57)
 		tool.use('brush').set(ui.palette.color(e.keyCode - 49));
+
+	// Shift Button Pressed
+	if ( e.keyIdentifier === "Shift" )
+		app.shiftHandler = true;
+
+}
+
+/**
+ * @param {event} e
+ * @private
+ */
+function onKeyUp(e) {
+
+	if ( e.keyIdentifier === "Shift" )
+		// Shift Button Unpressed
+		app.shiftHandler = false;
+
 }
 
 /**
@@ -1044,8 +1067,19 @@ brush.set = function(value) {
  * @param {scene} scene
  */
 brush.click = function(scene) {
-	if (scene.add(color))
-		history.push(scene.remove.bind(scene, scene.selected().clone()));
+
+ 	if ( !app.shiftHandler ){	// DRAW
+
+		if (scene.add(color))
+			history.push(scene.remove.bind(scene, scene.selected().clone()));
+
+	} else {					// ERASE
+
+		if (scene.remove())
+			history.push(scene.add.bind(scene, color, scene.selected().clone() ));
+
+	}
+
 };
 
 /**
@@ -1053,12 +1087,27 @@ brush.click = function(scene) {
  * @param {scene} scene
  */
 brush.drag = function(scene) {
-	if (scene.add(color)) {
-		if (!history.isSequenced())
-			history.startSequence();
 
-		history.push(scene.remove.bind(scene, scene.selected().clone()));
+	if ( !app.shiftHandler ) {	// DRAW
+
+		if (scene.add(color)) {
+			if (!history.isSequenced())
+				history.startSequence();
+
+			history.push(scene.remove.bind(scene, scene.selected().clone()));
+		}
+
+	} else {	// ERASE
+
+		if (scene.remove()) {
+			if (!history.isSequenced())
+				history.startSequence();
+
+			history.push(scene.add.bind(scene, color, scene.selected().clone() ));
+		}
+
 	}
+
 };
 
 /**

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -161,6 +161,7 @@ function persist( local ) {
 
 	if ( local ) {
 		console.log(JSON.stringify(data));
+		persistLock = false;
 		return;		
 	}
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -38,6 +38,11 @@ var fullCanvased = false;
 var app = {};
 
 /**
+ *  Shift Detect
+ */
+app.shiftHandler = false;
+
+/**
  *
  */
 app.init = function() {
@@ -97,6 +102,7 @@ function logCurious() {
  */
 function bindShortcuts() {
 	document.addEventListener('keydown', onKeyDown);
+	document.addEventListener('keyup', onKeyUp);
 }
 
 /**
@@ -261,6 +267,23 @@ function onKeyDown(e) {
 	// 123456789
 	if (e.keyCode >= 49 && e.keyCode <= 57)
 		tool.use('brush').set(ui.palette.color(e.keyCode - 49));
+
+	// Shift Button Pressed
+	if ( e.keyIdentifier === "Shift" )
+		app.shiftHandler = true;
+
+}
+
+/**
+ * @param {event} e
+ * @private
+ */
+function onKeyUp(e) {
+
+	if ( e.keyIdentifier === "Shift" )
+		// Shift Button Unpressed
+		app.shiftHandler = false;
+
 }
 
 /**

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -146,7 +146,7 @@ function save(silent) {
 /**
  * @private
  */
-function persist() {
+function persist( local ) {
 	if (persistLock) return;
 	persistLock = true;
 
@@ -158,6 +158,11 @@ function persist() {
 
 	// saves locally
 	var data = save();
+
+	if ( local ) {
+		console.log(JSON.stringify(data));
+		return;		
+	}
 
 	// persist to a gist
 	storage.persist(data, function(err, info) {
@@ -244,7 +249,19 @@ function onKeyDown(e) {
 		// ctrl + s
 		case 83:
 			e.preventDefault();
-			if (e.ctrlKey) persist();
+			if (e.ctrlKey) {
+
+				if (e.shiftKey){
+
+					persist( true );
+
+				} else {
+	
+					persist();
+
+				}
+
+			}
 			break;
 
 		// n

--- a/scripts/tools/brush.js
+++ b/scripts/tools/brush.js
@@ -42,8 +42,19 @@ brush.set = function(value) {
  * @param {scene} scene
  */
 brush.click = function(scene) {
-	if (scene.add(color))
-		history.push(scene.remove.bind(scene, scene.selected().clone()));
+
+ 	if ( !app.shiftHandler ){	// DRAW
+
+		if (scene.add(color))
+			history.push(scene.remove.bind(scene, scene.selected().clone()));
+
+	} else {					// ERASE
+
+		if (scene.remove())
+			history.push(scene.add.bind(scene, color, scene.selected().clone() ));
+
+	}
+
 };
 
 /**
@@ -51,12 +62,27 @@ brush.click = function(scene) {
  * @param {scene} scene
  */
 brush.drag = function(scene) {
-	if (scene.add(color)) {
-		if (!history.isSequenced())
-			history.startSequence();
 
-		history.push(scene.remove.bind(scene, scene.selected().clone()));
+	if ( !app.shiftHandler ) {	// DRAW
+
+		if (scene.add(color)) {
+			if (!history.isSequenced())
+				history.startSequence();
+
+			history.push(scene.remove.bind(scene, scene.selected().clone()));
+		}
+
+	} else {	// ERASE
+
+		if (scene.remove()) {
+			if (!history.isSequenced())
+				history.startSequence();
+
+			history.push(scene.add.bind(scene, color, scene.selected().clone() ));
+		}
+
 	}
+
 };
 
 /**

--- a/scripts/ui/palette.js
+++ b/scripts/ui/palette.js
@@ -55,6 +55,8 @@ palette.init = function() {
 		tool.use(btn.dataset.tool).set(btn.dataset.value);
 
 		active = e.target;
+
+		palette.toggle();
 	});
 };
 


### PR DESCRIPTION
Hi there. Awesome tool!

Please review the following changes I've made:
- Users can now draw and erase without toggling between 'b' and 'e'. Erase blocks by holding down Shift while drawing.
- Users can now press Ctrl+Shift+S, and display the data locally (console) rather than post to a Gist.
- Quicker color selection. Users can now press Space, select a color and the color palette automatically fades out.
